### PR TITLE
Update links for TensorFlow installation.

### DIFF
--- a/setup.ipynb
+++ b/setup.ipynb
@@ -52,9 +52,9 @@
    "source": [
     "## TensorFlow\n",
     "\n",
-    "Instructions for [installing TensorFlow with Anaconda or pip](https://anaconda.org/jjhelmus/tensorflow). \n",
+    "Instructions for [installing TensorFlow with Anaconda or pip](https://anaconda.org/conda-forge/tensorflow). \n",
     "\n",
-    "Here are [more details in case neither of those meets your needs](https://www.tensorflow.org/versions/r0.7/get_started/os_setup.html#download-and-setup)."
+    "Here are [more details in case neither of those meets your needs](https://www.tensorflow.org/install/#download-and-setup)."
    ]
   },
   {


### PR DESCRIPTION
Old links would install TensorFlow 0.7. New links will install
TensorFlow 1.5.