### PR TITLE
Fix a typo that broke link to setup.ipynb

### DIFF
--- a/vsm_02_dimreduce.ipynb
+++ b/vsm_02_dimreduce.ipynb
@@ -86,7 +86,7 @@
    "source": [
     "## Set-up\n",
     "\n",
-    "* Make sure your environment meets all the requirements for [the cs224u repository](https://github.com/cgpotts/cs224u/). For help getting set-up, see [setup.ipynb](setup.ipynb]).\n",
+    "* Make sure your environment meets all the requirements for [the cs224u repository](https://github.com/cgpotts/cs224u/). For help getting set-up, see [setup.ipynb](setup.ipynb).\n",
     "\n",
     "* Make sure you've downloaded [the data distribution for this unit](http://web.stanford.edu/class/cs224u/data/vsmdata.zip), unpacked it, and placed it in the current directory (or wherever you point `data_home` to below)."
    ]


### PR DESCRIPTION
Link to setup.ipynb had an extra ']' that resulted in a broken link.