### PR TITLE
Fix two typos in nli_01_task_and_data.ipynb

### DIFF
--- a/nli_01_task_and_data.ipynb
+++ b/nli_01_task_and_data.ipynb
@@ -147,7 +147,7 @@
    "source": [
     "## Properties of the corpora\n",
     "\n",
-    "For both SNLI and MultiNLI, MTurk annotator were presented with premise sentences and asked to produce new sentences that entailed, contradicted, or were neutral with respect to the premise. A subset of the examples were then validated by an additional four MTurk annotators."
+    "For both SNLI and MultiNLI, MTurk annotators were presented with premise sentences and asked to produce new sentences that entailed, contradicted, or were neutral with respect to the premise. A subset of the examples were then validated by an additional four MTurk annotators."
    ]
   },
   {
@@ -434,7 +434,7 @@
     "\n",
     "1. Regular string representations of the data\n",
     "1. Unlabeled binary parses \n",
-    "1. Labeled binary parses"
+    "1. Labeled parses"
    ]
   },
   {


### PR DESCRIPTION
Fix two typos in nli_01_task_and_data.ipynb