### PR TITLE
Remove zero padding for date 10, fix typo

### DIFF
--- a/semparse_dateparse.ipynb
+++ b/semparse_dateparse.ipynb
@@ -294,7 +294,7 @@
     "\n",
     "days = [str(d) for d in range(1, 32)]\n",
     "\n",
-    "days_padded = [str(i).zfill(2) for i in range(1, 11)]\n",
+    "days_padded = [str(i).zfill(2) for i in range(1, 10)]\n",
     "\n",
     "# Add to the rules list here:\n",
     "\n",
@@ -549,7 +549,7 @@
     "\n",
     "As noted above, only Americans use the `month/day/year` order. This suggests that we can disambiguate otherwise ambiguous dates by writing a feature function that is sensitive to this pre-terminal ordering and the associated informal timezone string.\n",
     "\n",
-    "__Your task__: Complete `timezone_sensitivity_features` so that, when given an input `parse`, it returns a `dict` of length 1 that maps the concatenation of the the timezone string and the pre-terminal nodes to `1`. You'll likely want to make use of `get_lemmas` and `get_timezone` to do this. (See `test_timezone_sensitivity_features` for a test, in case this description is ambiguous.)"
+    "__Your task__: Complete `timezone_sensitivity_features` so that, when given an input `parse`, it returns a `dict` of length 1 that maps the concatenation of the timezone string and the pre-terminal nodes to `1`. You'll likely want to make use of `get_lemmas` and `get_timezone` to do this. (See `test_timezone_sensitivity_features` for a test, in case this description is ambiguous.)"
    ]
   },
   {


### PR DESCRIPTION
Removing the zero padding for date 10 doesn't affect the number of lexical/unary/binary rules and ensures oracle accuracy is 100%. Not removing this results in multiple duplicate parses, for instance output parses 1 and 2 of `parse_and_interpret("2015 4 10 US")` are the same:  
```
======================================================================
Parse 1: [$DATE [$DATE [$Y 2015] [$MonthDay [$M 4] [$D 10]]] [$TZ US]]
Denotation: 2015-04-10
======================================================================
Parse 2: [$DATE [$DATE [$Y 2015] [$MonthDay [$M 4] [$D 10]]] [$TZ US]]
Denotation: 2015-04-10
======================================================================
Parse 3: [$DATE [$DATE [$Y 2015] [$MonthDay [$D 4] [$M 10]]] [$TZ US]]
Denotation: 2015-10-04
```