### PR TITLE
Add v1 fix_random_seed function

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -8,6 +8,9 @@ from scipy import stats
 from sklearn.metrics import f1_score
 from sklearn.model_selection import GridSearchCV
 import sys
+import os
+import torch
+import tensorflow as tf
 
 __author__ = "Christopher Potts"
 __version__ = "CS224u, Stanford, Spring 2019"
@@ -224,3 +227,33 @@ def tf_train_progress_logging():
     def info_filter(logrec):
         return int('loss' in logrec.getMessage().lower())
     logging.getLogger('tensorflow').addFilter(info_filter)
+
+def fix_random_seed(seed=42, set_torch_cudnn=True):
+    """Fix random seeds for reproducibility.
+
+    Parameters
+    ----------
+    seed : int
+        Random seed to be set.
+
+    set_torch_cudnn: bool
+        Flag for whether to enable cudnn deterministic mode.
+        Note that deterministic mode can have a performance impact, depending on your model.
+        https://pytorch.org/docs/stable/notes/randomness.html
+
+    """
+
+    # set system seed
+    np.random.seed(seed)
+    random.seed(seed)
+
+    # set torch seed
+    torch.manual_seed(seed)
+
+    # set torch cudnn backend
+    if set_torch_cudnn:
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+    # set tf seed
+    tf.random.set_random_seed(seed)


### PR DESCRIPTION
Add a util function that fixes random seeds for `random`, `np.random`, `PyTorch` and `TensorFlow`.

Note that even though the random seeds are explicitly set, the behaviors may still not be deterministic (especially when GPU is enabled), due to:

CUDA: There are some PyTorch functions that use CUDA functions that can be a source of non-determinism. (see tutorial [here](https://pytorch.org/docs/stable/notes/randomness.html))

PYTHONHASHSEED: [On Python 3.3 and greater, hash randomization is turned on by default.](https://docs.python.org/3.3/using/cmdline.html) This seed could be fixed before calling the python interpreter (`PYTHONHASHSEED=0 python test.py`). However, it seems impossible to set it inside the python program (see discussion [here](https://stackoverflow.com/questions/30585108/disable-hash-randomization-from-within-python-program)).



