### PR TITLE
Typo in autoencoder function name

### DIFF
--- a/vsm_02_dimreduce.ipynb
+++ b/vsm_02_dimreduce.ipynb
@@ -914,7 +914,7 @@
     "def randmatrix(m, n, sigma=0.1, mu=0):\n",
     "    return sigma * np.random.randn(m, n) + mu\n",
     "\n",
-    "def autoenoder_evaluation(nrow=1000, ncol=100, rank=20, max_iter=20000):\n",
+    "def autoencoder_evaluation(nrow=1000, ncol=100, rank=20, max_iter=20000):\n",
     "    \"\"\"This an evaluation in which `TfAutoencoder` should be able\n",
     "    to perfectly reconstruct the input data, because the\n",
     "    hidden representations have the same dimensionality as\n",
@@ -951,7 +951,7 @@
    "source": [
     "ae_max_iter = 100\n",
     "\n",
-    "_, _, ae = autoenoder_evaluation(max_iter=ae_max_iter)\n",
+    "_, _, ae = autoencoder_evaluation(max_iter=ae_max_iter)\n",
     "\n",
     "print(\"Autoencoder evaluation MSE after {0} evaluations: {1:0.04f}\".format(ae_max_iter, ae))"
    ]
@@ -1256,9 +1256,9 @@
  "metadata": {
   "celltoolbar": "Slideshow",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "nlu",
    "language": "python",
-   "name": "python3"
+   "name": "nlu"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1270,7 +1270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   },
   "widgets": {
    "state": {},


### PR DESCRIPTION
This is so small that not sure is worth a full PR, but just in case. Kernel metadata is "nlu" -- probably not a bad idea.