### PR TITLE
Keeps the full matrix off the GPU

### DIFF
--- a/torch_autoencoder.py
+++ b/torch_autoencoder.py
@@ -64,7 +64,7 @@ class TorchAutoencoder(TorchModelBase):
         dataset = torch.utils.data.TensorDataset(X_tensor, X_tensor)
         dataloader = torch.utils.data.DataLoader(
             dataset, batch_size=self.batch_size, shuffle=True,
-            pin_memory=False)
+            pin_memory=True)
         # Graph
         self.model = self.define_graph()
         self.model.to(self.device)
@@ -90,6 +90,7 @@ class TorchAutoencoder(TorchModelBase):
                     iteration, self.max_iter, err))
         # Hidden representations:
         with torch.no_grad():
+            self.model.to('cpu')
             H = self.model[1](self.model[0](X_tensor))
             return self.convert_output(H, X)
 
@@ -109,6 +110,7 @@ class TorchAutoencoder(TorchModelBase):
         self.model.eval()
         with torch.no_grad():
             X_tensor = self.convert_input_to_tensor(X)
+            self.model.to('cpu')
             X_pred = self.model(X_tensor)
             return self.convert_output(X_pred, X)
 
@@ -116,7 +118,6 @@ class TorchAutoencoder(TorchModelBase):
         if isinstance(X, pd.DataFrame):
             X = X.values
         X = torch.tensor(X, dtype=torch.float)
-        X = X.to(self.device)
         return X
 
     @staticmethod


### PR DESCRIPTION
@ignaciocases @zijwang - A student encountered a bug in `TorchAutoencoder`, and you both seemed to deduce that this was because the code was trying to move the entire incoming matrix to the GPU - if it didn't have space for that, the move was blocked, leading to an exception due to mixing GPU and CPU objects.

This PR fixes this by building on suggestions from Zijian:

* The full matrix is never moved to the GPU. Only matches are moved during training, along with the model parameters.

* For prediction, the model parameters are moved to the CPU so that they can accept the incoming matrix. This happens on lines 93 and 113.

I tested this on my local machine (CPU) and on an EC2 GPU machine. It's still an in-memory solution overall, but this is fine given the way the course materials work.

Do let me know if you see any concerns with this approach, and thanks!