### PR TITLE
Specify UTF-8 encoding explicitly when opening data files

### DIFF
--- a/hw1_wordsim.ipynb
+++ b/hw1_wordsim.ipynb
@@ -143,7 +143,7 @@
     "       downcased.\n",
     "\n",
     "    \"\"\"\n",
-    "    with open(src_filename) as f:\n",
+    "    with open(src_filename, encoding='utf8') as f:\n",
     "        reader = csv.reader(f, delimiter=delimiter)\n",
     "        if header:\n",
     "            next(reader)\n",

--- a/hw4_wordentail.ipynb
+++ b/hw4_wordentail.ipynb
@@ -127,7 +127,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(wordentail_filename) as f:\n",
+    "with open(wordentail_filename, encoding='utf8') as f:\n",
     "    wordentail_data = json.load(f)"
    ]
   },

--- a/nli.py
+++ b/nli.py
@@ -108,7 +108,7 @@ def bake_off_evaluation(experiment_results, test_data_filename=None):
     if test_data_filename is None:
         test_data_filename = os.path.join(
             'data', 'nlidata', 'nli_wordentail_bakeoff_data-test.json')
-    with open(test_data_filename) as f:
+    with open(test_data_filename, encoding='utf8') as f:
         wordentail_data = json.load(f)
     X_test, y_test = word_entail_featurize(
         wordentail_data['word_disjoint']['test'],
@@ -217,7 +217,7 @@ class NLIReader(object):
 
         """
         random.seed(self.random_state)
-        for line in open(self.src_filename):
+        for line in open(self.src_filename, encoding='utf8'):
             if (not self.samp_percentage) or random.random() <= self.samp_percentage:
                 d = json.loads(line)
                 ex = NLIExample(d)
@@ -291,7 +291,7 @@ def read_annotated_subset(src_filename, multinli_home):
         reader = MultiNLIMatchedDevReader(multinli_home)
     id2ex = {ex.pairID: ex for ex in reader.read()}
     data = {}
-    with open(src_filename) as f:
+    with open(src_filename, encoding='utf8') as f:
         for line in f:
             fields = line.split()
             pair_id = fields[0]

--- a/rel_ext.py
+++ b/rel_ext.py
@@ -29,9 +29,9 @@ class Corpus(object):
     @staticmethod
     def read_examples(src_filename):
         examples = []
-        with gzip.open(src_filename) as f:
+        with gzip.open(src_filename, mode='rt', encoding='utf8') as f:
             for line in f:
-                fields = line[:-1].decode('utf-8').split('\t')
+                fields = line[:-1].split('\t')
                 examples.append(Example(*fields))
         return examples
 
@@ -88,9 +88,9 @@ class KB(object):
     @staticmethod
     def read_kb_triples(src_filename):
         kb_triples = []
-        with gzip.open(src_filename) as f:
+        with gzip.open(src_filename, mode='rt', encoding='utf8') as f:
             for line in f:
-                rel, sbj, obj = line[:-1].decode('utf-8').split('\t')
+                rel, sbj, obj = line[:-1].split('\t')
                 kb_triples.append(KBTriple(rel, sbj, obj))
         return kb_triples
 

--- a/sst.py
+++ b/sst.py
@@ -41,7 +41,7 @@ def sentiment_treebank_reader(src_filename, class_func=None):
     """
     if class_func is None:
         class_func = lambda x: x
-    with open(src_filename) as f:
+    with open(src_filename, encoding='utf8') as f:
         for line in f:
             tree = Tree.fromstring(line)
             label = class_func(tree.label())

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -85,7 +85,7 @@ def cheese_disease_dataset():
     src_filename = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
         "cheeseDisease.train.txt")
-    with open(src_filename) as f:
+    with open(src_filename, encoding='utf8') as f:
         for line in f:
             label, ex = line.split("\t", 1)
             label = "cheese" if label.strip() == "1" else "disease"

--- a/test/test_nli.py
+++ b/test/test_nli.py
@@ -16,7 +16,7 @@ def wordentail_data():
     nlidata_home = os.path.join('data', 'nlidata')
     wordentail_filename = os.path.join(
         nlidata_home, 'nli_wordentail_bakeoff_data.json')
-    with open(wordentail_filename) as f:
+    with open(wordentail_filename, encoding='utf8') as f:
         data = json.load(f)
     return data
 

--- a/utils.py
+++ b/utils.py
@@ -26,7 +26,7 @@ def glove2dict(src_filename):
         Mapping words to their GloVe vectors.
     """
     data = {}
-    with open(src_filename) as f:
+    with open(src_filename, encoding='utf8') as f:
         while True:
             try:
                 line = next(f)


### PR DESCRIPTION
In text mode, if encoding is not specified the encoding used is platform dependent. If the system's encoding is not UTF-8 (usually the case in Windows), it may lead to incorrect behavior.
For example, when parsing the file line by line, carriage return (0x0D) can be detected in symbol č (0x010D), the line would be broken in the middle and incorrectly parsed.
It's better to specify input encoding explicitly.
p.s> Thanks for the course! :)