### PR TITLE
Minor typo fix

### DIFF
--- a/vsm_01_distributional.ipynb
+++ b/vsm_01_distributional.ipynb
@@ -908,7 +908,7 @@
     "\n",
     "Let's do a quick worked-out example. Suppose we have the count matrix $X$ = \n",
     "\n",
-    "|          | a  | b  | rowsum |\n",
+    "|    .     | a  | b  | rowsum |\n",
     "|----------|----|----|-------|\n",
     "| __x__    | 34 | 11 |  45   |\n",
     "| __y__    | 47 | 7  |  54   |\n",
@@ -920,7 +920,7 @@
     "\n",
     "And the full table looks like this:\n",
     "\n",
-    "|        | a    | b    | \n",
+    "|    .   | a    | b    | \n",
     "|--------|------|------|\n",
     "| __x__  | 0.92 | 1.34 | \n",
     "| __y__  | 1.06 | 0.71 |"

--- a/vsm_01_distributional.ipynb
+++ b/vsm_01_distributional.ipynb
@@ -1380,7 +1380,7 @@
     "  \n",
     "  to read in an adjective $\\times$ adverb matrix derived from the Gigaword corpus. Each cell contains the number of times that the modifier phrase __ADV ADJ__ appeared in Gigaword as given by dependency parses of the data. __ADJ__ is the row value and __ADV__ is the column value. Using the above techniques and measures, try to get a feel for what can be done with this matrix.\n",
     "\n",
-    "1. [Turney and Pantel (2010)](http://www.jair.org/media/2934/live-2934-4846-jair.pdf), p. 158, propose a \"contextual discounting\" extension of PMI to try to address its bias for low-frequency events. Extend `vsm.pmi` so that the user has the option of performing this discounting with the keyword argument `discounting=True`."
+    "1. [Turney and Pantel (2010)](https://jair.org/index.php/jair/article/view/10640), p. 158, propose a \"contextual discounting\" extension of PMI to try to address its bias for low-frequency events. Extend `vsm.pmi` so that the user has the option of performing this discounting with the keyword argument `discounting=True`."
    ]
   }
  ],

--- a/vsm_01_distributional.ipynb
+++ b/vsm_01_distributional.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "Why build distributed representations? There are potentially many reasons. The two we will emphasize in this course:\n",
     "\n",
-    "1. __Understanding words in context__: There is value to linguists in seeing what these data-rich approaches can teach use about natural language lexicons, and there is value for social scientists in understanding how words are being used.\n",
+    "1. __Understanding words in context__: There is value to linguists in seeing what these data-rich approaches can teach us about natural language lexicons, and there is value for social scientists in understanding how words are being used.\n",
     "\n",
     "1. __Feature representations for other models__: As we will see, many models can benefit from representing examples as distributed representations."
    ]


### PR DESCRIPTION
- s/can teach use/can teach us/
- Fixed the markdown table for Observed/Expected (using jupyter lab)
 empty cell seems to break the table format, adding a dummy char '.'
fixed the broken table format

**Now:**
<img width="499" alt="Screen Shot 2019-12-24 at 01 51 22" src="https://user-images.githubusercontent.com/1240382/71407787-e4400100-25f0-11ea-8224-398417e84365.png">

**Was:**

<img width="853" alt="Screen Shot 2019-12-24 at 01 58 51" src="https://user-images.githubusercontent.com/1240382/71407827-f7eb6780-25f0-11ea-88c8-88bdb9bb1178.png">


**fixed the broken link**

<img width="661" alt="Screen Shot 2019-12-24 at 02 57 25" src="https://user-images.githubusercontent.com/1240382/71410229-4997f000-25f9-11ea-965a-661774140a9c.png">
