### PR TITLE
Potential typo fix

### DIFF
--- a/sst_03_neural_networks.ipynb
+++ b/sst_03_neural_networks.ipynb
@@ -149,7 +149,7 @@
    "source": [
     "### GloVe inputs\n",
     "\n",
-    "To illustrate this process, we'll use the general purpose GloVe representations released by the GloVe team, at 50d:"
+    "To illustrate this process, we'll use the general purpose GloVe representations released by the GloVe team, at 300d:"
    ]
   },
   {


### PR DESCRIPTION
Could this be typo? since the code load `300d`

<img width="854" alt="Screen Shot 2020-01-15 at 01 12 16" src="https://user-images.githubusercontent.com/1240382/72421546-8e650180-3735-11ea-8362-037fab0d412a.png">

