### PR TITLE
Fixing a typo in nli_02_models.ipynb

### DIFF
--- a/nli_02_models.ipynb
+++ b/nli_02_models.ipynb
@@ -215,7 +215,7 @@
    "source": [
     "### Model wrapper\n",
     "\n",
-    "Our experiment framework is basically the same as the one we used for the Stanford Sentiment Treebank. Here, I actually use `sst.fit_classifier_with_crossvalidation` (from that unit) to create a wrapper around `LogisticRegression` for cross-validation of hyperparameters. At this point, I am not sure what parameters will be good for our NLI datasets, so this hyperparameter search is vital."
+    "Our experiment framework is basically the same as the one we used for the Stanford Sentiment Treebank. Here, I actually use `utils.fit_classifier_with_crossvalidation` (introduced in that unit) to create a wrapper around `LogisticRegression` for cross-validation of hyperparameters. At this point, I am not sure what parameters will be good for our NLI datasets, so this hyperparameter search is vital."
    ]
   },
   {


### PR DESCRIPTION
The module containing `fit_classifier_with_crossvalidation()` has
changed from `sst` to `utils`.