### PR TITLE
Add elapsed time to training verbose

### DIFF
--- a/np_glove.py
+++ b/np_glove.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 import random
 import sys
+import time
 import utils
 
 __author__ = "Christopher Potts"
@@ -87,6 +88,7 @@ class GloVe:
         X_weights = (np.minimum(X, self.xmax) / self.xmax)**self.alpha  # eq. (9)
         # Learning:
         indices = list(range(m))
+        t_start = time.time()
         for iteration in range(self.max_iter):
             epoch_error = 0.0
             random.shuffle(indices)
@@ -110,16 +112,17 @@ class GloVe:
                     epoch_error += 0.5 * weight * (diff**2)
 
             epoch_error /= m
+            elapsed = time.time() - t_start
 
             if epoch_error <= self.tol:
                 utils.progress_bar(
-                    "Converged on iteration {} with error {}".format(
-                        iteration, epoch_error, self.display_progress))
+                    "Converged on iteration {} with error {}; took {:.2f} seconds".format(
+                        iteration, epoch_error, elapsed, self.display_progress))
                 break
 
             utils.progress_bar(
-                "Finished epoch {} of {}; error is {}".format(
-                    iteration, self.max_iter, epoch_error, self.display_progress))
+                "Finished epoch {} of {}; error is {}; took {:.2f} seconds".format(
+                    iteration, self.max_iter, epoch_error, elapsed, self.display_progress))
 
         # Return the sum of the word and context matrices, per the advice
         # in section 4.2:

--- a/np_model_base.py
+++ b/np_model_base.py
@@ -1,3 +1,4 @@
+import time
 import numpy as np
 import random
 from utils import randvec, randmatrix, progress_bar, d_tanh
@@ -57,6 +58,7 @@ class NNModelBase(object):
         training_data = list(zip(X, y))
         # SGD:
         iteration = 0
+        t_start = time.time()
         for iteration in range(1, self.max_iter+1):
             error = 0.0
             random.shuffle(training_data)
@@ -68,17 +70,18 @@ class NNModelBase(object):
                     hidden_states, predictions, ex, labels)
                 self.update_parameters(gradients)
             error /= len(training_data)
+            elapsed = time.time() - t_start
             if error <= self.tol:
                 if self.display_progress:
                     progress_bar(
-                        "Converged on iteration {} with error {}".format(
-                            iteration, error))
+                        "Converged on iteration {} with error {}; took {:.2f} seconds".format(
+                            iteration, error, elapsed))
                 break
             else:
                 if self.display_progress:
                     progress_bar(
-                        "Finished epoch {} of {}; error is {}".format
-                        (iteration, self.max_iter, error))
+                        "Finished epoch {} of {}; error is {}; took {:.2f} seconds".format
+                        (iteration, self.max_iter, error, elapsed))
         return self
 
     @staticmethod

--- a/torch_model_base.py
+++ b/torch_model_base.py
@@ -1,6 +1,7 @@
 import copy
 import numpy as np
 import pickle
+import time
 from sklearn.model_selection import train_test_split
 import torch
 import torch.nn as nn
@@ -346,6 +347,7 @@ class TorchModelBase:
         self.model.train()
         self.optimizer.zero_grad()
 
+        t_start = time.time()
         for iteration in range(1, self.max_iter+1):
 
             epoch_error = 0.0
@@ -377,6 +379,8 @@ class TorchModelBase:
                     self.optimizer.step()
                     self.optimizer.zero_grad()
 
+            elapsed = time.time() - t_start
+
             # Stopping criteria:
 
             if self.early_stopping:
@@ -385,8 +389,8 @@ class TorchModelBase:
                     utils.progress_bar(
                         "Stopping after epoch {}. Validation score did "
                         "not improve by tol={} for more than {} epochs. "
-                        "Final error is {}".format(iteration, self.tol,
-                            self.n_iter_no_change, epoch_error),
+                        "Final error is {}; took {:.2f} seconds".format(iteration, self.tol,
+                            self.n_iter_no_change, epoch_error, elapsed),
                         verbose=self.display_progress)
                     break
 
@@ -396,13 +400,13 @@ class TorchModelBase:
                     utils.progress_bar(
                         "Stopping after epoch {}. Training loss did "
                         "not improve more than tol={}. Final error "
-                        "is {}.".format(iteration, self.tol, epoch_error),
+                        "is {}; took {:.2f} seconds".format(iteration, self.tol, epoch_error, elapsed),
                         verbose=self.display_progress)
                     break
 
             utils.progress_bar(
-                "Finished epoch {} of {}; error is {}".format(
-                    iteration, self.max_iter, epoch_error),
+                "Finished epoch {} of {}; error is {}; took {:.2f} seconds".format(
+                    iteration, self.max_iter, epoch_error, elapsed),
                 verbose=self.display_progress)
 
         if self.early_stopping:


### PR DESCRIPTION
Adding elapsed time for training helps:
- Development process so users can understand the turn-around time
- Estimation of full training time
- Comparison during parameter tuning