### PR TITLE
Fixed typo in hw_wordentail.ipynb

### DIFF
--- a/hw_wordentail.ipynb
+++ b/hw_wordentail.ipynb
@@ -109,7 +109,7 @@
     "\n",
     "I've processed the data into a train/dev split that is designed to put some pressure on our models to actually learn these semantic relations, as opposed to exploiting regularities in the sample. \n",
     "\n",
-    "The defining feature of the dataset is that the `train` and `dev` __vocabularies__ are disjoint. That is, if a word `w` appears in a training pair, it does not occur in any text pair. It follows from this that there are also no word-pairs shared between train and dev, as you would expect. This should require your models to learn abstract relationships, as opposed to memorizing incidental properties of individual words in the dataset."
+    "The defining feature of the dataset is that the `train` and `dev` __vocabularies__ are disjoint. That is, if a word `w` appears in a training pair, it does not occur in any test pair. It follows from this that there are also no word-pairs shared between train and dev, as you would expect. This should require your models to learn abstract relationships, as opposed to memorizing incidental properties of individual words in the dataset."
    ]
   },
   {


### PR DESCRIPTION
Minor thing, but could improve understanding. In hw_wordentail.ipynb:

"That is, if a word w appears in a training pair, it does not occur in any **text** pair. "

should read as:

"That is, if a word w appears in a training pair, it does not occur in any **test** pair. "