### PR TITLE
Set PyTorch version to 1.8.0

### DIFF
--- a/setup.ipynb
+++ b/setup.ipynb
@@ -139,7 +139,7 @@
     "\n",
     "The PyTorch library has special installation instructions depending on your computing environment. For Anaconda users, we recommend\n",
     "\n",
-    "```conda install pytorch torchvision -c pytorch```\n",
+    "```conda install pytorch=1.8.0 torchvision -c pytorch```\n",
     "\n",
     "For non-Anaconda users, or if you have a [CUDA-enabled GPU](https://developer.nvidia.com/cuda-gpus), we recommend following the instructions posted here:\n",
     "\n",


### PR DESCRIPTION
Make `conda` to use PyTorch version 1.8.0. If not specified, it will use 1.9.0 or more recent, which might be not compatible with the current version of the code.