### PR TITLE
Add `IS_GRADESCOPE_ENV` guard to bake-off function call

### DIFF
--- a/hw_colors.ipynb
+++ b/hw_colors.ipynb
@@ -1240,7 +1240,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "create_bakeoff_submission(dev_mod)"
+    "# This check ensure that the following code only runs on the local environment only.\n",
+    "# The following call will not be run on the autograder environment.\n",
+    "if 'IS_GRADESCOPE_ENV' not in os.environ:\n",
+    "    pass\n",
+    "    create_bakeoff_submission(dev_mod)"
    ]
   },
   {
@@ -1293,7 +1297,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/hw_sentiment.ipynb
+++ b/hw_sentiment.ipynb
@@ -900,7 +900,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "create_bakeoff_submission(predict_one_softmax)"
+    "# This check ensure that the following code only runs on the local environment only.\n",
+    "# The following call will not be run on the autograder environment.\n",
+    "if 'IS_GRADESCOPE_ENV' not in os.environ:\n",
+    "    pass\n",
+    "    create_bakeoff_submission(predict_one_softmax)"
    ]
   },
   {
@@ -946,7 +950,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.8"
   },
   "widgets": {
    "state": {},

--- a/hw_wordrelatedness.ipynb
+++ b/hw_wordrelatedness.ipynb
@@ -983,7 +983,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "create_bakeoff_submission(count_df, vsm.euclidean)"
+    "# This check ensure that the following code only runs on the local environment only.\n",
+    "# The following call will not be run on the autograder environment.\n",
+    "if 'IS_GRADESCOPE_ENV' not in os.environ:\n",
+    "    pass\n",
+    "    create_bakeoff_submission(count_df, vsm.euclidean)"
    ]
   },
   {
@@ -1029,7 +1033,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.8"
   },
   "widgets": {
    "state": {},


### PR DESCRIPTION
- this is to avoid running bake-off function call in the autograder
  environment
- without this any non-trivial bake-off function call will be either
  timed out or failed due to missing modules