### PR TITLE
Number of duplicate entries in SST train set are 10 and not one

### DIFF
--- a/sst_01_overview.ipynb
+++ b/sst_01_overview.ipynb
@@ -279,7 +279,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This removes only one example for this setting so it is unlikely to be a significant choice."
+    "This removes only ten examples for this setting so it is unlikely to be a significant choice."
    ]
   },
   {


### PR DESCRIPTION
Sir,

I think there is a small typo in `sst_01_overview.ipynb`.

According to the output of code cell 7, there are 8544 instances in `train_df`, and according to code cell 10 there are 8534 instances in `dup_train_df` which has duplicate entries removed. So in the markdown cell just below cell 10, the number of duplicate entries should be 8544-8534=10, and not one.

This is a screenshot:

![Screenshot from 2021-09-07 18-03-55](https://user-images.githubusercontent.com/55744224/132382649-310e0ff9-2cfa-4fd3-bb44-3121227dabbf.png)