### PR TITLE
Fixed typos: replaced 'tree' with 'text'

### DIFF
--- a/sst_02_hand_built_features.ipynb
+++ b/sst_02_hand_built_features.ipynb
@@ -186,7 +186,7 @@
     "    Returns\n",
     "    -------\n",
     "    defaultdict\n",
-    "        A map from strings to their counts in `tree`. (Counter maps a\n",
+    "        A map from strings to their counts in `text`. (Counter maps a\n",
     "        list to a dict of counts of the elements in that list.)\n",
     "\n",
     "    \"\"\"\n",

--- a/sst_03_neural_networks.ipynb
+++ b/sst_03_neural_networks.ipynb
@@ -164,7 +164,7 @@
    "outputs": [],
    "source": [
     "def vsm_phi(text, lookup, np_func=np.mean):\n",
-    "    \"\"\"Represent `tree` as a combination of the vector of its words.\n",
+    "    \"\"\"Represent `text` as a combination of the vector of its words.\n",
     "\n",
     "    Parameters\n",
     "    ----------\n",
@@ -178,7 +178,7 @@
     "        like `np.mean`, `np.sum`, or `np.prod`. The requirement is that\n",
     "        the function take `axis=0` as one of its arguments (to ensure\n",
     "        columnwise combination) and that it return a vector of a\n",
-    "        fixed length, no matter what the size of the tree is.\n",
+    "        fixed length, no matter what the size of the text is.\n",
     "\n",
     "    Returns\n",
     "    -------\n",


### PR DESCRIPTION
Sir I think these are typos: it should be `text` not `tree`.