### PR TITLE
Fix variable typo: DATE_HOME -> DATA_HOME.

### DIFF
--- a/sst_03_neural_networks.ipynb
+++ b/sst_03_neural_networks.ipynb
@@ -101,13 +101,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DATE_HOME = 'data'\n",
+    "DATA_HOME = 'data'\n",
     "\n",
-    "GLOVE_HOME = os.path.join(DATE_HOME, 'glove.6B')\n",
+    "GLOVE_HOME = os.path.join(DATA_HOME, 'glove.6B')\n",
     "\n",
-    "VSMDATA_HOME = os.path.join(DATE_HOME, 'vsmdata')\n",
+    "VSMDATA_HOME = os.path.join(DATA_HOME, 'vsmdata')\n",
     "\n",
-    "SST_HOME = os.path.join(DATE_HOME, 'sentiment')"
+    "SST_HOME = os.path.join(DATA_HOME, 'sentiment')"
    ]
   },
   {


### PR DESCRIPTION
Hi!

I think there is a typo in the variable name "DATE_HOME". I have changed it to "DATA_HOME". 

Hope it helps!

Miguel