### PR TITLE
Rename method name: fit_maxent_classifier -> fit_softmax_classifier

### DIFF
--- a/sst_03_neural_networks.ipynb
+++ b/sst_03_neural_networks.ipynb
@@ -120,7 +120,7 @@
     "\n",
     "<img src=\"fig/distreps-as-features.png\" width=500 alt=\"distreps-as-features.png\" />\n",
     "\n",
-    "Our model will just be `LogisticRegression`, and we'll continue with the experiment framework from the previous notebook. Here is `fit_maxent_classifier` again:"
+    "Our model will just be `LogisticRegression`, and we'll continue with the experiment framework from the previous notebook. Here is `fit_softmax_classifier` again:"
    ]
   },
   {
@@ -129,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def fit_maxent_classifier(X, y):\n",
+    "def fit_softmax_classifier(X, y):\n",
     "    mod = LogisticRegression(\n",
     "        fit_intercept=True,\n",
     "        solver='liblinear',\n",
@@ -233,7 +233,7 @@
     "_ = sst.experiment(\n",
     "    sst.train_reader(SST_HOME),\n",
     "    glove_phi,\n",
-    "    fit_maxent_classifier,\n",
+    "    fit_softmax_classifier,\n",
     "    assess_dataframes=sst.dev_reader(SST_HOME),\n",
     "    vectorize=False)  # Tell `experiment` that we already have our feature vectors."
    ]
@@ -323,7 +323,7 @@
     "_ = sst.experiment(\n",
     "    sst.train_reader(SST_HOME),\n",
     "    yelp_phi,\n",
-    "    fit_maxent_classifier,\n",
+    "    fit_softmax_classifier,\n",
     "    assess_dataframes=sst.dev_reader(SST_HOME),\n",
     "    vectorize=False)  # Tell `experiment` that we already have our feature vectors."
    ]


### PR DESCRIPTION
Hi!

In the previous notebook, this method is named "fit_softmax_classifier", instead of "fit_maxent_classifier".

Considering that this notebook contains the following mention to the previous notebook, I have thought it would be nice to have both method named the same:

> Our model will just be `LogisticRegression`, and we'll continue with the experiment framework from the previous notebook. Here is `fit_maxent_classifier` again:

Hope it helps!

Miguel