### PR TITLE
Fix typo: perpelexities -> perplexities

### DIFF
--- a/colors_overview.ipynb
+++ b/colors_overview.ipynb
@@ -1129,7 +1129,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can get the perplexities for test examples with `perpelexities`:"
+    "You can get the perplexities for test examples with `perplexities`:"
    ]
   },
   {


### PR DESCRIPTION
Hi!

I have fixed a small typo: perpelexities -> perplexities.

Hope it helps!
Miguel