### PR TITLE
Add colab badge

### DIFF
--- a/hw_openqa.ipynb
+++ b/hw_openqa.ipynb
@@ -13,7 +13,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/insop/cs224u/blob/master/hw_openqa.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/cgpotts/cs224u/blob/master/hw_openqa.ipynb)\n",
+    "\n",
+    "If colab is opened with this badge, please **save copy to drive** in 'File' menu before running the notebook."
    ]
   },
   {

--- a/hw_openqa.ipynb
+++ b/hw_openqa.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/insop/cs224u/blob/master/hw_openqa.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/insop/cs224u/blob/master/hw_openqa.ipynb)"
    ]
   },
   {

--- a/hw_openqa.ipynb
+++ b/hw_openqa.ipynb
@@ -10,6 +10,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/insop/cs224u/blob/master/hw_openqa.ipynb)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {


### PR DESCRIPTION
Please consider to add colab badge inside the notebook. This allows to open the notebook to Colab, so that only Github copy need to be provided instead of providing both github and colab links.
<img width="1029" alt="Screen Shot 2022-06-07 at 10 48 34 PM" src="https://user-images.githubusercontent.com/1240382/172542725-ce8993f2-0c15-42ac-b0b0-1e4c4d0adbc8.png">

