### PR TITLE
Changes for conda env and hw2 for Feb 2024 cohort

### DIFF
--- a/hw_openqa.ipynb
+++ b/hw_openqa.ipynb
@@ -126,7 +126,27 @@
     "from datasets import load_dataset\n",
     "import openai\n",
     "import os\n",
-    "import dsp"
+    "import dsp\n",
+    "from dotenv import load_dotenv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eeb63387",
+   "metadata": {},
+   "source": [
+    "Save the API keys in a `.env` file in the local root directory as follows. Then, `load_dotenv()` will make them available to the notebook:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73e176f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# keep the API keys in a `.env` file in the local root directory\n",
+    "load_dotenv()"
    ]
   },
   {
@@ -138,9 +158,9 @@
    "source": [
     "os.environ[\"DSP_NOTEBOOK_CACHEDIR\"] = os.path.join(root_path, 'cache')\n",
     "\n",
-    "openai_key = os.getenv('OPENAI_API_KEY')  # or replace with your API key (optional)\n",
+    "openai_key = os.getenv('OPENAI_API_KEY')  # save the key to .env file\n",
     "\n",
-    "cohere_key = os.getenv('COHERE_API_KEY')  # or replace with your API key (optional)\n",
+    "cohere_key = os.getenv('COHERE_API_KEY')  # save the key to .env file\n",
     "\n",
     "colbert_server = 'http://index.contextual.ai:8893/api/search'"
    ]
@@ -160,7 +180,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lm = dsp.GPT3(model='text-davinci-001', api_key=openai_key)\n",
+    "lm = dsp.GPT3(model='gpt-3.5-turbo-instruct', api_key=openai_key)\n",
     "\n",
     "# Options for Cohere: command-medium-nightly, command-xlarge-nightly\n",
     "#lm = dsp.Cohere(model='command-xlarge-nightly', api_key=cohere_key)\n",
@@ -185,7 +205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# [d[\"root\"] for d in openai.Model.list()[\"data\"]]"
+    "# [d['id'] for d in openai.Model.list()['data']]"
    ]
   },
   {
@@ -351,7 +371,7 @@
     "\n",
     "    Returns\n",
     "    -------\n",
-    "    dict with keys \"df\", \"em\", \"f1\" storung assessment data\n",
+    "    dict with keys \"df\", \"em\", \"f1\" storing assessment data\n",
     "    \"\"\"\n",
     "    data = []\n",
     "    for example in tqdm.tqdm(dev):\n",
@@ -951,6 +971,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0971daff",
+   "metadata": {},
+   "source": [
+    "You can also see the full set of results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a5fad19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# few_shot_qa_results['df'].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "eeb28556-d901-4b6b-8a7d-93040203294d",
    "metadata": {},
    "source": [
@@ -1006,7 +1044,6 @@
     "\n",
     "    # Return the Completions instance returned by `dsp.generate`:\n",
     "    ##### YOUR CODE HERE\n",
-    "\n",
     "\n"
    ]
   },
@@ -1116,6 +1153,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9bd6afd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# few_shot_openqa_with_context_results['df'].head()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "9971ffd0-a563-4d56-a896-0735a63ae92f",
    "metadata": {
@@ -1132,7 +1179,7 @@
    "source": [
     "This question is designed to give you some experience with DSP's powerful `annotate` method. You can think of this as a generic tool for defining general aspects of your prompt. Here we will use it to filter the set of demonstrations we use.\n",
     "\n",
-    "The overall idea here is that the demonstrations we sample might vary in quality in ways that could impact model performance. For example, if we want to try to push the model to provide extractive answers as in classical QA – answers that are substrings of the evidence passage – then it works against our interests to include demonstrations where the model is unabel to do this.\n",
+    "The overall idea here is that the demonstrations we sample might vary in quality in ways that could impact model performance. For example, if we want to try to push the model to provide extractive answers as in classical QA – answers that are substrings of the evidence passage – then it works against our interests to include demonstrations where the model is unable to do this.\n",
     "\n",
     "We will do this in two parts to facilitate testing."
    ]
@@ -1175,6 +1222,7 @@
     "\n",
     "    # Sample `k=3` demonstrations to help the model assess this\n",
     "    # potential demonstration:\n",
+    "    # `squad_train` could be used for this. \n",
     "    ##### YOUR CODE HERE\n",
     "\n",
     "\n",
@@ -1188,7 +1236,6 @@
     "\n",
     "    # Return d, if you got this far:\n",
     "    ##### YOUR CODE HERE\n",
-    "\n",
     "\n"
    ]
   },
@@ -1393,6 +1440,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32da9f2d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# filtering_results['df'].head()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "19655d70-007c-4a41-9f3b-e20df9c5169b",
    "metadata": {},
@@ -1568,7 +1625,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/hw_openqa.ipynb
+++ b/hw_openqa.ipynb
@@ -158,9 +158,9 @@
    "source": [
     "os.environ[\"DSP_NOTEBOOK_CACHEDIR\"] = os.path.join(root_path, 'cache')\n",
     "\n",
-    "openai_key = os.getenv('OPENAI_API_KEY')  # save the key to .env file\n",
+    "openai_key = os.getenv('OPENAI_API_KEY')  # or replace with your API key (optional)\n",
     "\n",
-    "cohere_key = os.getenv('COHERE_API_KEY')  # save the key to .env file\n",
+    "cohere_key = os.getenv('COHERE_API_KEY')  # or replace with your API key (optional)\n",
     "\n",
     "colbert_server = 'http://index.contextual.ai:8893/api/search'"
    ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,11 @@ pandas>=1.5
 torch==1.13.1
 torchvision==0.14.1
 transformers==4.26.1
-datasets==2.10.1
+# https://stackoverflow.com/questions/77671277/valueerror-invalid-pattern-can-only-be-an-entire-path-component
+datasets==2.16.1
 spacy==3.5.1
 dsp-ml<0.2
-openai
+# https://github.com/stanfordnlp/dspy/issues/220
+openai==0.28.1
 cohere
+python-dotenv


### PR DESCRIPTION
Changes for for Feb 2024 cohort:

> this PR is for cond env and hw2 
> more PR will follow after checking hw1 and hw3
> if time permits, will check if dspy can be integrated

Change list in this PR:

- due to compatibility issue, use openai==0.28.x version for the compatibility.
    https://github.com/stanfordnlp/dspy/issues/220

- due to compatibility issue, datasets==2.16.1
    https://stackoverflow.com/questions/77671277/valueerror-invalid-pattern-can-only-be-an-entire-path-component

- update model to gpt-3.5-turbo-instruct due to model deprecation text-davinci-001

    > The model `text-davinci-001` has been deprecated, learn more here: https://platform.openai.com/docs/deprecations

- use `dotenv` to load API keys
    https://saurabh-kumar.com/python-dotenv/