### PR TITLE
Fix dspy-ai version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pandas>=1.5
 transformers==4.37.1
 datasets==2.14.6
 spacy==3.7.2
-dspy-ai
+dspy-ai==2.3.1
 # dependencies for dspy-ai
 openai<=0.28.1
 python-dotenv


### PR DESCRIPTION
- there are various changes that will breakk the current hw2 notebook after 2.3.2